### PR TITLE
Add uri filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /test/dummy/log/*.log
 /test/dummy/storage/
 /test/dummy/tmp/
+.ruby-version
+Gemfile.lock

--- a/app/models/concerns/webhooks/outgoing/uri_filtering.rb
+++ b/app/models/concerns/webhooks/outgoing/uri_filtering.rb
@@ -1,0 +1,151 @@
+require "resolv"
+require "public_suffix"
+
+module Webhooks::Outgoing::UriFiltering
+  extend ActiveSupport::Concern
+
+  # WEBHOOK SECURITY PRIMER
+  # =============================================================================
+  # Outgoing webhooks can be dangerous. By allowing your users to set
+  # up outgoing webhooks, you"re giving them permission to call arbitrary
+  # URLs from your server, including URLs that could represent resources
+  # internal to your company. Malicious actors can use this permission to
+  # examine your infrastructure, call internal APIs, and generally cause
+  # havok.
+
+  # This module attempts to block malicious actors with the following algorithm
+  #   1. Block anything but http and https requests
+  #   2. Block or allow defined hostnames, both regex and strings
+  #   3. Block if `custom_block_callback` returns true (args: self, uri)
+  #   4. Allow if `custom_allow_callback` returns true (args: self, uri)
+  #   5. Resolve the IP associated with the webhook"s host directly from
+  #      the authoritative name server for the host"s domain. This IP
+  #      is cached for the returned DNS TTL
+  #   6. Match the given IP against lists of allowed and blocked cidr ranges.
+  #      The blocked list by default includes all of the defined private address
+  #      ranges, localhost, the private IPv6 prefix, and the AWS metadata
+  #      API endpoint.
+
+  # If at any point a URI is determined to be blocked we call `audit_callback`
+  # (args: self, uri) so it can be logged for auditing.
+
+  # We resolve the IP from the authoritative name server directly so we can avoid
+  # certain classes of DNS poisoning attacks.
+
+  # Users of this gem are _strongly_ enouraged to add additional cidr ranges
+  # and hostnames to the appropriate lists and/or implement `custom_block_callback`.
+  # At the very least you should add the public hostname that your
+  # application uses to the blocked_hostnames list.
+
+  class AllowedUriValidator < ActiveModel::EachValidator
+    def validate_each(record, attribute, value)
+      uri = URI.parse(value)
+      unless allowed_uri?(uri)
+        record.errors[attribute] << "is not an allowed uri"
+      end
+    end
+  end
+
+  def resolve_ip_from_authoritative(hostname)
+    begin
+      ip = IPAddr.new(hostname)
+      return ip.to_s
+    rescue IPAddr::InvalidAddressError
+      # this is fine, proceed with resolver path
+    end
+
+    cache_key = "#{cache_key_with_version}/uri_ip/#{Digest::SHA2.hexdigest(hostname)}"
+
+    cached = Rails.cache.read(cache_key)
+    if cached
+      return cached == "invalid" ? nil : cached
+    end
+
+    begin
+      # This is sort of a half-recursive DNS resolver.
+      # We can't implement a full recursive resolver using just Resolv::DNS so instead
+      # this asks a public cache for the NS record for the given domain. Then it asks
+      # the authoritative nameserver directly for the address and caches it according
+      # to the returned TTL.
+
+      config = Rails.configuration.outgoing_webhooks
+      ns_resolver = Resolv::DNS.new(nameserver: config[:public_resolvers])
+      ns_resolver.timeouts = 1
+
+      domain = PublicSuffix.domain(hostname)
+      authoritative = ns_resolver.getresource(domain, Resolv::DNS::Resource::IN::NS)
+
+      authoritative_resolver = Resolv::DNS.new(nameserver: [authoritative.name.to_s])
+      authoritative_resolver.timeouts = 1
+
+      resource = authoritative_resolver.getresource(hostname, Resolv::DNS::Resource::IN::A)
+      Rails.cache.write(cache_key, resource.address.to_s, expires_in: resource.ttl, race_condition_ttl: 5)
+      resource.address.to_s
+    rescue IPAddr::InvalidAddressError, ArgumentError # standard:disable Lint/ShadowedException
+      Rails.cache.write(cache_key, "invalid", expires_in: 10.minutes, race_condition_ttl: 5)
+      nil
+    end
+  end
+
+  def allowed_uri?(uri)
+    unless _allowed_uri?(uri)
+      config = Rails.configuration.outgoing_webhooks
+      if config[:audit_callback].present?
+        config[:audit_callback].call(self, uri)
+      end
+      return false
+    end
+
+    true
+  end
+
+  def _allowed_uri?(uri)
+    config = Rails.configuration.outgoing_webhooks
+    hostname = uri.hostname.downcase
+
+    return false unless config[:allowed_schemes].include?(uri.scheme)
+
+    config[:blocked_hostnames].each do |blocked|
+      if blocked.is_a?(Regexp)
+        return false if blocked.match?(hostname)
+      end
+
+      return false if blocked == hostname
+    end
+
+    config[:allowed_hostnames].each do |allowed|
+      if allowed.is_a?(Regexp)
+        return true if allowed.match?(hostname)
+      end
+
+      return true if allowed == hostname
+    end
+
+    if config[:custom_allow_callback].present?
+      return true if config[:custom_allow_callback].call(self, uri)
+    end
+
+    if config[:custom_block_callback].present?
+      return false if config[:custom_block_callback].call(self, uri)
+    end
+
+    resolved_ip = resolve_ip_from_authoritative(hostname)
+    return false if resolved_ip.nil?
+
+    begin
+      config[:allowed_cidrs].each do |cidr|
+        return true if IPAddr.new(cidr).include?(resolved_ip)
+      end
+
+      config[:blocked_cidrs].each do |cidr|
+        return false if IPAddr.new(cidr).include?(resolved_ip)
+      end
+
+      
+    rescue IPAddr::InvalidAddressError
+      return false
+    end
+
+    true
+  end
+end

--- a/app/models/webhooks/outgoing/delivery_attempt.rb
+++ b/app/models/webhooks/outgoing/delivery_attempt.rb
@@ -23,9 +23,17 @@ class Webhooks::Outgoing::DeliveryAttempt < ApplicationRecord
 
   def attempt
     uri = URI.parse(delivery.endpoint_url)
-    http = Net::HTTP.new(uri.host, uri.port)
+
+    unless allowed_uri?(uri)
+      self.response_code = 0
+      self.error_message = "URI is not allowed: " + uri
+      return false
+    end
+
+    http = Net::HTTP.new(resolve_ip_from_authoritative(uri.hostname.downcase), uri.port)
     http.use_ssl = true if uri.scheme == "https"
     request = Net::HTTP::Post.new(uri.path)
+    request.add_field("Host", uri.host)
     request.add_field("Content-Type", "application/json")
     request.body = delivery.event.payload.to_json
 

--- a/app/models/webhooks/outgoing/endpoint.rb
+++ b/app/models/webhooks/outgoing/endpoint.rb
@@ -14,6 +14,7 @@ class Webhooks::Outgoing::Endpoint < ApplicationRecord
   # 🚅 add scopes above.
 
   validates :name, presence: true
+  validates :url, presence: true, allowed_uri: true
   # 🚅 add validations above.
 
   # 🚅 add callbacks above.

--- a/bullet_train-outgoing_webhooks.gemspec
+++ b/bullet_train-outgoing_webhooks.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_dependency "rails", ">= 7.0.0"
+  spec.add_dependency "public_suffix"
 end

--- a/lib/bullet_train/outgoing_webhooks/engine.rb
+++ b/lib/bullet_train/outgoing_webhooks/engine.rb
@@ -27,7 +27,7 @@ module BulletTrain
       end
 
       initializer "bullet_train.outgoing_webhooks.register_api_endpoints" do |app|
-        if BulletTrain::Api
+        if Object.const_defined?('BulletTrain::Api')
           BulletTrain::Api.endpoints << "Api::V1::Webhooks::Outgoing::EndpointsEndpoint"
           BulletTrain::Api.endpoints << "Api::V1::Webhooks::Outgoing::DeliveriesEndpoint"
           BulletTrain::Api.endpoints << "Api::V1::Webhooks::Outgoing::DeliveryAttemptsEndpoint"

--- a/lib/bullet_train/outgoing_webhooks/engine.rb
+++ b/lib/bullet_train/outgoing_webhooks/engine.rb
@@ -1,6 +1,31 @@
 module BulletTrain
   module OutgoingWebhooks
     class Engine < ::Rails::Engine
+      config.before_configuration do
+        default_blocked_cidrs = %w[
+          10.0.0.0/8
+          172.16.0.0/12
+          192.168.0.0/16
+          100.64.0.0/10
+          127.0.0.0/8
+          169.254.169.254/32
+          fc00::/7
+          ::1
+        ]
+
+        config.outgoing_webhooks = {
+          blocked_cidrs: default_blocked_cidrs,
+          allowed_cidrs: [],
+          blocked_hostnames: %w[localhost],
+          allowed_hostnames: [],
+          public_resolvers: %w[8.8.8.8 1.1.1.1],
+          allowed_schemes: %w[http https],
+          custom_block_callback: nil,
+          custom_allow_callback: nil,
+          audit_callback: ->(obj, uri) { Rails.logger.error("BlockedURI obj=#{obj.to_global_id} uri=#{uri}") }
+        }
+      end
+
       initializer "bullet_train.outgoing_webhooks.register_api_endpoints" do |app|
         if BulletTrain::Api
           BulletTrain::Api.endpoints << "Api::V1::Webhooks::Outgoing::EndpointsEndpoint"

--- a/test/models/concerns/webhooks/outgoing/uri_filtering_test.rb
+++ b/test/models/concerns/webhooks/outgoing/uri_filtering_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Webhooks::Outgoing::UriFilteringTest < ActiveSupport::TestCase
+  class DummyModel
+    include Webhooks::Outgoing::UriFiltering
+
+    def cache_key_with_version
+      "dummy"
+    end
+
+    def to_global_id
+      "dummy_id"
+    end
+  end
+
+  def assert_allowed_uri(uri)
+    m = DummyModel.new
+    assert(m.allowed_uri?(URI.parse(uri)))
+  end
+
+  def refute_allowed_uri(uri)
+    m = DummyModel.new
+    refute(m.allowed_uri?(URI.parse(uri)))
+  end
+
+  test "allowed_uri?" do
+    assert_allowed_uri("http://www.example.com")
+    assert_allowed_uri("https://www.example.com")
+    assert_allowed_uri("http://104.16.16.194")
+
+    refute_allowed_uri("http://localhost")
+    refute_allowed_uri("http://LOCALHOST")
+    refute_allowed_uri("telnet://www.example.com")
+
+    refute_allowed_uri("http://192.168.1.1")
+    refute_allowed_uri("http://10.0.0.1")
+    refute_allowed_uri("http://172.16.0.1")
+    refute_allowed_uri("http://100.64.1.1")
+    refute_allowed_uri("http://127.0.0.1")
+    refute_allowed_uri("http://169.254.169.254")
+    refute_allowed_uri("http://[fd12:3456:789a:1::1]")
+    refute_allowed_uri("http://[::1]")
+  end
+end


### PR DESCRIPTION
This PR adds URI filtering to outgoing webhooks. We don't want users to be able to make webhook requests to our application or other internal resources that our machine may have access to. We filter both as a model validation and when attempting delivery. We do both because a validation gives immediate feedback to users but can't be trusted because a user could enter a valid hostname, change it to a private IP, and then make a webhook request.

This PR is heavily inspired by [Smokescreen](https://github.com/stripe/smokescreen), a filtering egress proxy written in Go. We use the same ideas as smokescreen and apply them as a Rails concern with a small modification to DNS resolution. Smokescreen assumes an upstream recursive resolver (i.e. running unbound as a sidecar) whereas we can't assume that for applications using Bullettrain. Instead we do a partially recursive resolution, where we ask an upstream server for the NS record for the domain and then ask the authoritative server directly for the A record.