### PR TITLE
Remove most webhook database reads from hot path

### DIFF
--- a/app/jobs/webhooks/outgoing/generate_job.rb
+++ b/app/jobs/webhooks/outgoing/generate_job.rb
@@ -1,0 +1,7 @@
+class Webhooks::Outgoing::GenerateJob < ApplicationJob
+  queue_as :default
+
+  def perform(obj, action)
+    obj.generate_webhook_perform(action)
+  end
+end

--- a/app/models/concerns/webhooks/outgoing/issuing_model.rb
+++ b/app/models/concerns/webhooks/outgoing/issuing_model.rb
@@ -13,7 +13,14 @@ module Webhooks::Outgoing::IssuingModel
   module ClassMethods
   end
 
+  def skip_generate_webhook?(action)
+    false
+  end
+
   def generate_webhook(action)
+    # allow individual models to opt out of generating webhooks
+    return if skip_generate_webhook?(action)
+
     # we can only generate webhooks for objects that return their team.
     return unless respond_to? :team
 
@@ -25,25 +32,31 @@ module Webhooks::Outgoing::IssuingModel
     if event_type && team
 
       # Only generate an event record if an endpoint is actually listening for this event type.
-      if team.webhooks_outgoing_endpoints.listening_for_event_type_id(event_type.id).any?
-        data = "Api::V1::#{self.class.name}Serializer".constantize.new(self).serializable_hash[:data]
-        webhook = team.webhooks_outgoing_events.create(event_type_id: event_type.id, subject: self, data: data)
-        webhook.deliver
+      if team.endpoints_listening_for_event_type?(event_type)
+        # serialization can be heavy so run it as a job
+        Webhooks::Outgoing::GenerateJob.perform_later(self, action)
       end
     end
   end
 
+  def generate_webhook_perform(action)
+    event_type = Webhooks::Outgoing::EventType.find_by(id: "#{self.class.name.underscore}.#{action}")
+    data = "Api::V1::#{self.class.name}Serializer".constantize.new(self).serializable_hash[:data]
+    webhook = team.webhooks_outgoing_events.create(event_type_id: event_type.id, subject: self, data: data)
+    webhook.deliver
+  end
+
   def generate_created_webhook
-    generate_webhook("created")
+    generate_webhook(:created)
   end
 
   def generate_updated_webhook
-    generate_webhook("updated")
+    generate_webhook(:updated)
   end
 
   def generate_deleted_webhook
     return false unless respond_to?(:team)
     return false if team&.being_destroyed?
-    generate_webhook("deleted")
+    generate_webhook(:deleted)
   end
 end

--- a/app/models/concerns/webhooks/outgoing/team_support.rb
+++ b/app/models/concerns/webhooks/outgoing/team_support.rb
@@ -8,6 +8,24 @@ module Webhooks::Outgoing::TeamSupport
     before_destroy :mark_for_destruction, prepend: true
   end
 
+  class_methods do
+    def should_cache_endpoints_listening_for_event_type?
+      true
+    end
+
+    def endpoints_listening_for_event_type?(event_type)
+      if should_cache_endpoints_listening_for_event_type?
+        key = "#{cache_key_with_version}/endpoints_for_event_type/#{event_type.cache_key}"
+
+        Rails.cache.fetch(key, expires_in: 24.hours, race_condition_ttl: 5.seconds) do
+          webhooks_outgoing_endpoints.listening_for_event_type_id(event_type.id).any?
+        end
+      else
+        webhooks_outgoing_endpoints.listening_for_event_type_id(event_type.id).any?
+      end
+    end
+  end
+
   def mark_for_destruction
     # This allows downstream logic to check whether a team is being destroyed in order to bypass webhook issuance.
     update_column(:being_destroyed, true)

--- a/app/models/webhooks/outgoing/endpoint.rb
+++ b/app/models/webhooks/outgoing/endpoint.rb
@@ -16,6 +16,8 @@ class Webhooks::Outgoing::Endpoint < ApplicationRecord
   validates :name, presence: true
   # 🚅 add validations above.
 
+  after_save :touch_team
+
   # 🚅 add callbacks above.
 
   # 🚅 add delegations above.
@@ -26,6 +28,11 @@ class Webhooks::Outgoing::Endpoint < ApplicationRecord
 
   def event_types
     event_type_ids.map { |id| Webhooks::Outgoing::EventType.find(id) }
+  end
+
+  # touch team to invalidate endpoints_listening_for_event_type? cache
+  def touch_team
+    team.touch
   end
 
   # 🚅 add methods above.


### PR DESCRIPTION
Webhook generation can be a remarkably large part of any given transaction. This removes most database reads from `IssuingModel#generate_webhook` by caching the listening endpoint lookup and pushing the serialization into a job. 